### PR TITLE
added configuration settings and code support with defaults

### DIFF
--- a/index.rb
+++ b/index.rb
@@ -3,8 +3,10 @@ require 'json'
 require_relative 'miro.rb'
 require_relative 'colors.rb'
 
-# Set custom port
-set :port, 8089
+# Set bind address (network interface)
+set :bind, defined?(PHLOEM_BIND) ? PHLOEM_BIND : 'localhost' 
+# Set port
+set :port, defined?(PHLOEM_PORT) ? PHLOEM_PORT : 8089 
 
 # React to an incoming webhook payload
 post '/payload/issues' do

--- a/sample_config.rb
+++ b/sample_config.rb
@@ -1,3 +1,5 @@
+PHLOEM_BIND = 'localhost'                    # Should be localhost in dev, might be 0.0.0.0 in live/standalone
+PHLOEM_PORT = 8089                    # Must be available
 CLIENT_ID = '3647883846667980995'      # Must be replaced from "manage apps" settings in Miro
 CLIENT_SECRET = 'EDQnTsuCBivNEgrCOaDJ' # Must be replaced from "manage apps" settings in Miro
 ACCESS_TOKEN = "723a9bc4-c729-620b-4f8d-d38fdc68a993" # From Miro

--- a/sample_config.rb
+++ b/sample_config.rb
@@ -1,5 +1,5 @@
-PHLOEM_BIND = 'localhost'                    # Should be localhost in dev, might be 0.0.0.0 in live/standalone
-PHLOEM_PORT = 8089                    # Must be available
+PHLOEM_BIND = 'localhost'              # Should be localhost in dev, might be 0.0.0.0 in live/standalone
+PHLOEM_PORT = 8089                     # Must be available
 CLIENT_ID = '3647883846667980995'      # Must be replaced from "manage apps" settings in Miro
 CLIENT_SECRET = 'EDQnTsuCBivNEgrCOaDJ' # Must be replaced from "manage apps" settings in Miro
 ACCESS_TOKEN = "723a9bc4-c729-620b-4f8d-d38fdc68a993" # From Miro


### PR DESCRIPTION
bind could also use APP_ENV or other Sinatra/Ruby features, so might want to check that this brute force makes sense; similarly, native/common alternatives for port might be readily available